### PR TITLE
- Fix for a breaking change in `puppet-stdlib` version 8.3.0 (https:/…

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -24,6 +24,8 @@ appveyor.yml:
   user: rehanone
   secure: "WiS9j4aI93DobVH/O/z6aHKOY8UL2hwn4+fflKuhvZzJPxfsYYfvQsyX43qetpVAIW7DCZLfO1QQlLF1/ywhe8Y9XRy923R6E7WckYPCGtGBpeTdS7p3Biss2H+ikxI9/5UFlewrdFxLxqgKz8lGLCt8zL1r7ggPWjJBfWEBtk2J9mj4BRTTGt6SWTSHwkdqjloQsPu32SXWY4nsU+87p+lO49YTOH2cS+54/DRCpccPl2AL+kXISDGiDZtlMyGdL2c0Z1e8etmOxbHN2X80YyOQY2GiKdGhzVfx5TDPElDXkOO5JkkZWmsz2D6BJYvu+s9awIJ6/pzGFDghZIK2MSgfUjJd9Vwt1lm48kHKsJ3DsSRIOHK+2ft/3nUl8y7j7KKQMcKKVN35/0uy/cXnD4acuxCh84e5bc0pmYy0gxLhLF6C9Ahv8pls7HhA+jaoUBNXIgCb685w6EgrkaeGMx1vz7VfZo56viod/zZ7XCXg8o5s7vthKMtYLnuGIEl2DvBC3KKtGvl4RnzFVUcZcB5lHgLZozskcwuWFtqd/AgqdIVRzKc6KmRWo8TkE/qOV79MaUpKGONmLMQfsz01HMn4m/NAmu4J55kFgFYkrkwy+9c/3Z9Ytce7goOnyxYYd0fFfaSM8vJCl7oe8Zb3znK2atMmpQAfDwYBwUNe1jU="
   docker_sets:
+#    - set: ubuntu2204-64
+#      collection: puppet7
     - set: ubuntu2004-64
       collection: puppet7
     - set: ubuntu2004-64
@@ -35,8 +37,6 @@ appveyor.yml:
     - set: ubuntu1604-64
       collection: puppet7
     - set: ubuntu1604-64
-      collection: puppet6
-    - set: ubuntu1404-64
       collection: puppet6
     - set: debian11-64
       collection: puppet7

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,15 +85,6 @@ jobs:
     -
       bundler_args: --with system_tests
       dist: focal
-      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_setfile=ubuntu1404-64 BEAKER_TESTMODE=apply
-      rvm: 2.5.7
-      script: bundle exec rake beaker
-      services: docker
-      stage: acceptance
-      sudo: required
-    -
-      bundler_args: --with system_tests
-      dist: focal
       env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_HYPERVISOR=docker BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_setfile=debian11-64 BEAKER_TESTMODE=apply
       rvm: 2.5.7
       script: bundle exec rake beaker

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,21 +15,21 @@ autorestic::architecture: "%{facts.os.architecture}"
 autorestic::os_type: 'linux'
 
 autorestic::restic_ensure: present
-autorestic::restic_version: '0.13.0'
+autorestic::restic_version: '0.13.1'
 autorestic::restic_download_file_extension: "bz2"
 autorestic::restic_download_filename: "restic_%{lookup('autorestic::restic_version')}_%{lookup('autorestic::os_type')}_%{lookup('autorestic::architecture')}"
 autorestic::restic_download_url: "https://github.com/restic/restic/releases/download/v%{lookup('autorestic::restic_version')}/%{lookup('autorestic::restic_download_filename')}.%{lookup('autorestic::restic_download_file_extension')}"
-autorestic::restic_checksum: '514d0711317427f45d3ca23e66cf66e9f98caef660314d843f59b38511e94a2c'
+autorestic::restic_checksum: 'a7a82eca050224c9cd070fea1d4208fe92358c5942321d6e01eff84a77839fb8'
 autorestic::restic_checksum_type: sha256
 autorestic::restic_global_install_directory: '/opt/restic'
 autorestic::restic_global_install_ensure: absent
 
 autorestic::autorestic_ensure: present
-autorestic::autorestic_version: '1.5.8'
+autorestic::autorestic_version: '1.7.1'
 autorestic::autorestic_download_file_extension: "bz2"
 autorestic::autorestic_download_filename: "autorestic_%{lookup('autorestic::autorestic_version')}_%{lookup('autorestic::os_type')}_%{lookup('autorestic::architecture')}"
 autorestic::autorestic_download_url: "https://github.com/cupcakearmy/autorestic/releases/download/v%{lookup('autorestic::autorestic_version')}/%{lookup('autorestic::autorestic_download_filename')}.%{lookup('autorestic::autorestic_download_file_extension')}"
-autorestic::autorestic_checksum: '38b679de469a559ab5e932d86007d6f9d0e50b412a25d4af961ad9a880791777'
+autorestic::autorestic_checksum: 'd90e9a390155c6b9b8044dfa8a5abc55f62cff32807ce5b0e46e69f0f5f40d93'
 autorestic::autorestic_checksum_type: sha256
 autorestic::autorestic_install_directory: '/opt/autorestic'
 

--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -3,6 +3,8 @@ class autorestic::dependencies () inherits autorestic {
   assert_private("Use of private class ${name} by ${caller_module_name}")
 
   if $autorestic::dependencies_manage {
-    ensure_packages([$autorestic::dependencies_packages], { 'ensure' => present })
+    package { [$autorestic::dependencies_packages]:
+      ensure => installed,
+    }
   }
 }


### PR DESCRIPTION
…/github.com/puppetlabs/puppetlabs-stdlib/pull/1196)

- Added unit test coverage for Ubuntu 22.04.
- Removed test coverage for Ubuntu 14.04.